### PR TITLE
add react 16.0.0 compatibility

### DIFF
--- a/lib/ReactDynamicFont.js
+++ b/lib/ReactDynamicFont.js
@@ -1,14 +1,12 @@
 'use strict';
 
-Object.defineProperty(exports, "__esModule", {
-  value: true
-});
-
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
+
+import PropTypes from 'prop-types'
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -130,11 +128,11 @@ var ReactDynamicFont = function (_Component) {
 }(_react.Component);
 
 ReactDynamicFont.propTypes = {
-  content: _react.PropTypes.string.isRequired,
-  smooth: _react.PropTypes.bool.isRequired
+  content: PropTypes.string.isRequired,
+  smooth: PropTypes.bool.isRequired
 };
 ReactDynamicFont.defaultProps = {
   content: '',
   smooth: false
 };
-exports.default = ReactDynamicFont;
+export default ReactDynamicFont;


### PR DESCRIPTION
Fixes error "Could not read property String of undefined" from line 133 as PropTypes seem to not be available on the react main package.